### PR TITLE
Add basic search page template with a search form

### DIFF
--- a/frontend/src/components/Search/Search.html
+++ b/frontend/src/components/Search/Search.html
@@ -1,1 +1,98 @@
-<h2>Search page</h2>
+<div>
+  <h2>Search Non Profits</h2>
+
+  <form id="form" class="form" action="" method="post">
+    <h3 class="form-prompt">Search for a Non Profit</h3>
+
+    <label for="cause">Search by Cause</label>
+    <select id="cause" class="dropdown">
+      <option value="any">Any</option>
+      <option value="animals">Animals</option>
+      <option value="children">Children</option>
+      <option value="community">Community</option>
+      <option value="economical-justice">Economical Justice</option>
+      <option value="environment">Environment</option>
+      <option value="foreign-policy">Foreign Policy</option>
+      <option value="health">Health</option>
+      <option value="media">Media</option>
+      <option value="natural-resources">Natural Resources</option>
+      <option value="peace">Peace</option>
+      <option value="refugees">Refugees</option>
+      <option value="social-justice">Social Justice</option>
+      <option value="technology">Technology</option>
+      <option value="wildlife">Wildlife</option>
+      <option value="women">Women</option>
+    </select>
+    <br>
+    
+    <label for="state">Search by State</label>
+    <select id="state" class="dropdown">
+      <option value="any">Any</option>
+      <option value="alabama">Alabama</option>
+      <option value="alaska">Alaska</option>
+      <option value="arizona">Arizona</option>
+      <option value="arkansas">Arkansas</option>
+      <option value="california">California</option>
+      <option value="colorado">Colorado</option>
+      <option value="connecticut">Connecticut</option>
+      <option value="delaware">Delaware</option>
+      <option value="florida">Florida</option>
+      <option value="georgia">Georgia</option>
+      <option value="hawaii">Hawaii</option>
+      <option value="idaho">Idaho</option>
+      <option value="illinois">Illinois</option>
+      <option value="indiana">Indiana</option>
+      <option value="iowa">Iowa</option>
+      <option value="kansas">Kansas</option>
+      <option value="kentucky">Kentucky</option>
+      <option value="louisiana">Louisiana</option>
+      <option value="maine">Maine</option>
+      <option value="maryland">Maryland</option>
+      <option value="massachusetts">Massachusetts</option>
+      <option value="michigan">Michigan</option>
+      <option value="minnesota">Minnesota</option>
+      <option value="mississippi">Mississippi</option>
+      <option value="missouri">Missouri</option>
+      <option value="montana">Montana</option>
+      <option value="nebraska">Nebraska</option>
+      <option value="nevada">Nevada</option>
+      <option value="new-hampshire">New Hampshire</option>
+      <option value="new-jersey">New Jersey</option>
+      <option value="new-mexico">New Mexico</option>
+      <option value="new-york">New York</option>
+      <option value="north-carolina">North Carolina</option>
+      <option value="north-dakota">North Dakota</option>
+      <option value="ohio">Ohio</option>
+      <option value="oklahoma">Oklahoma</option>
+      <option value="oregon">Oregon</option>
+      <option value="pennsylvania">Pennsylvania</option>
+      <option value="rhode-island">Rhode Island</option>
+      <option value="south-carolina">South Carolina</option>
+      <option value="south-dakota">South Dakota</option>
+      <option value="tennessee">Tennessee</option>
+      <option value="texas">Texas</option>
+      <option value="utah">Utah</option>
+      <option value="vermont">Vermont</option>
+      <option value="virginia">Virginia</option>
+      <option value="washington">Washington</option>
+      <option value="west-virginia">West Virginia</option>
+      <option value="wisconsin">Wisconsin</option>
+      <option value="wyoming">Wyoming</option>
+    </select>
+    <br>
+
+    <label for="zip">Search by zip code</label>
+    <input type="text" name="zip" id="zip">
+    <br>
+
+    <label for="size">Search by Organization Size</label>
+    <select id="size" class="dropdown">
+      <option value="any">Any</option>
+      <option value="small">Small</option>
+      <option value="large">Large</option>
+    </select>
+    <br>
+    <input type="submit" value="Submit">
+
+  </form>
+</div>


### PR DESCRIPTION
Added very basic form, including a search by `cause`, `state`, `zip code`, and `size`.
Cause, State, and Size are drop down menus. Zip code is a text input field. 
 